### PR TITLE
Add bzl_libraries

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -4,6 +4,7 @@ module(
 )
 
 bazel_dep(name = "platforms", version = "0.0.10")
+bazel_dep(name = "bazel_skylib", version = "1.6.1")
 
 sh_configure = use_extension("//shell/private/extensions:sh_configure.bzl", "sh_configure")
 use_repo(sh_configure, "local_config_shell")

--- a/shell/BUILD
+++ b/shell/BUILD
@@ -9,7 +9,20 @@
 # Bazel's sh_* rules.
 #
 # Toolchains registered for this type should have target constraints.
+
+load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
+
 toolchain_type(
     name = "toolchain_type",
     visibility = ["//visibility:public"],
+)
+
+bzl_library(
+    name = "rules_bzl",
+    srcs = [
+        "sh_binary.bzl",
+        "sh_library.bzl",
+        "sh_test.bzl",
+    ],
+    deps = ["//shell/private:private_bzl"],
 )

--- a/shell/BUILD
+++ b/shell/BUILD
@@ -25,4 +25,5 @@ bzl_library(
         "sh_test.bzl",
     ],
     deps = ["//shell/private:private_bzl"],
+    visibility = ["//visibility:public"],
 )

--- a/shell/BUILD
+++ b/shell/BUILD
@@ -24,6 +24,6 @@ bzl_library(
         "sh_library.bzl",
         "sh_test.bzl",
     ],
-    deps = ["//shell/private:private_bzl"],
     visibility = ["//visibility:public"],
+    deps = ["//shell/private:private_bzl"],
 )

--- a/shell/private/BUILD
+++ b/shell/private/BUILD
@@ -1,0 +1,7 @@
+load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
+
+bzl_library(
+    name = "private_bzl",
+    srcs = ["sh_executable.bzl"],
+    visibility = ["//shell:__pkg__"],
+)


### PR DESCRIPTION
Needed to generate documentation for build encyclopedia. There are links in Bazel docs to sh rules and the generator complains if the Sh rules docs are removed / break those links.