### PR TITLE
Guard `reproducible` usage behind `bazel_features` check

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -6,45 +6,35 @@ matrix:
     - ubuntu2004
     - macos
     - windows
+  bazel:
+    - 6.5.0
+    - 7.3.2
 
 tasks:
   test_module_bzlmod:
-    name: "Test module (Bazel 7.3.2, Bzlmod)"
+    name: "Test module (Bzlmod)"
     working_directory: "tests/bcr"
-    bazel: 7.3.2
+    bazel: ${{ bazel }}
     platform: ${{ platform }}
     build_flags:
       - "--enable_bzlmod"
-      - "--noenable_workspace"
     build_targets:
       - "//..."
     test_flags:
       - "--enable_bzlmod"
-      - "--noenable_workspace"
     test_targets:
       - "//..."
   test_module_workspace:
-    name: "Test module (Bazel 7.3.2, WORKSPACE)"
+    name: "Test module (WORKSPACE)"
     working_directory: "tests/bcr"
-    bazel: 7.3.2
+    bazel: ${{ bazel }}
     platform: ${{ platform }}
     build_flags:
-      - "--noenable_bzlmod"
-      - "--enable_workspace"
+      - "--enable_bzlmod"
     build_targets:
       - "//..."
     test_flags:
-      - "--noenable_bzlmod"
-      - "--enable_workspace"
-    test_targets:
-      - "//..."
-  test_module_workspace_bazel6:
-    name: "Test module (Bazel 6.5.0, WORKSPACE)"
-    working_directory: "tests/bcr"
-    bazel: 6.5.0
-    platform: ${{ platform }}
-    build_targets:
-      - "//..."
+      - "--enable_bzlmod"
     test_targets:
       - "//..."
   test_module_head:
@@ -52,13 +42,7 @@ tasks:
     working_directory: "tests/bcr"
     bazel: last_green
     platform: ${{ platform }}
-    build_flags:
-      - "--enable_bzlmod"
-      - "--noenable_workspace"
     build_targets:
       - "//..."
-    test_flags:
-      - "--enable_bzlmod"
-      - "--noenable_workspace"
     test_targets:
       - "//..."

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -3,8 +3,9 @@ module(
     version = "0.0.0",
 )
 
-bazel_dep(name = "platforms", version = "0.0.10")
+bazel_dep(name = "bazel_features", version = "1.18.0")
 bazel_dep(name = "bazel_skylib", version = "1.6.1")
+bazel_dep(name = "platforms", version = "0.0.10")
 
 sh_configure = use_extension("//shell/private/extensions:sh_configure.bzl", "sh_configure")
 use_repo(sh_configure, "local_config_shell")

--- a/shell/private/extensions/sh_configure.bzl
+++ b/shell/private/extensions/sh_configure.bzl
@@ -14,10 +14,13 @@
 
 """The sh_configure module extension."""
 
+load("@bazel_features//:features.bzl", "bazel_features")
 load("//shell/private/repositories:sh_config.bzl", "sh_config")
 
 def _sh_configure_impl(module_ctx):
     sh_config(name = "local_config_shell")
-    return module_ctx.extension_metadata(reproducible = True)
+    if bazel_features.external_deps.extension_metadata_has_reproducible:
+        return module_ctx.extension_metadata(reproducible = True)
+    return None
 
 sh_configure = module_extension(implementation = _sh_configure_impl)


### PR DESCRIPTION
This is needed for Bazel 6 compatibility with Bzlmod enabled.