### PR TITLE
Fix runfiles.bash and start using it

### DIFF
--- a/shell/runfiles/BUILD
+++ b/shell/runfiles/BUILD
@@ -9,6 +9,7 @@ alias(
 
 sh_library(
     name = "runfiles_impl",
+    srcs = [":runfiles.bash"],
     data = [":runfiles_at_legacy_location"],
     tags = ["manual"],
 )

--- a/shell/runfiles/runfiles.bash
+++ b/shell/runfiles/runfiles.bash
@@ -69,7 +69,7 @@
 #
 #       # --- begin runfiles.bash initialization v3 ---
 #       # Copy-pasted from the Bazel Bash runfiles library v3.
-#       set -uo pipefail; set +e; f=bazel_tools/tools/bash/runfiles/runfiles.bash
+#       set -uo pipefail; set +e; f=rules_shell+/shell/runfiles/runfiles.bash
 #       # shellcheck disable=SC1090
 #       source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
 #         source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
@@ -90,7 +90,11 @@ if [[ ! -d "${RUNFILES_DIR:-/dev/null}" && ! -f "${RUNFILES_MANIFEST_FILE:-/dev/
     export RUNFILES_MANIFEST_FILE="$0.runfiles_manifest"
   elif [[ -f "$0.runfiles/MANIFEST" ]]; then
     export RUNFILES_MANIFEST_FILE="$0.runfiles/MANIFEST"
-  elif [[ -f "$0.runfiles/bazel_tools/tools/bash/runfiles/runfiles.bash" ]]; then
+  elif [[ -f "$0.runfiles/rules_shell/shell/runfiles/runfiles.bash" ]]; then
+    export RUNFILES_DIR="$0.runfiles"
+  elif ls "$0.runfiles/rules_shell~"*"/shell/runfiles/runfiles.bash" 1> /dev/null 2>&1; then
+    export RUNFILES_DIR="$0.runfiles"
+  elif [[ -f "$0.runfiles/rules_shell+/shell/runfiles/runfiles.bash" ]]; then
     export RUNFILES_DIR="$0.runfiles"
   fi
 fi


### PR DESCRIPTION
The `runfiles.bash` file was added in #13 but was never used. This is probably the reason why it was never adapted to the new location. This PR fixes the script and starts using it. Note that it keeps the old runfiles script as a dependency to avoid breaking bootstrap snippets (tests with old bootstrap still pass). See #22 for two potential follow-ups (1. adapt tests to use runfiles script from this repo and 2. remove dependency to script from bazel_tools).