### PR TITLE
Make runfiles.bash available via PATH in all sh_*() rules

### DIFF
--- a/shell/private/sh_executable.bzl
+++ b/shell/private/sh_executable.bzl
@@ -44,7 +44,11 @@ def _sh_executable_impl(ctx):
         main_executable = symlink
 
     files = depset(direct = direct_files)
-    runfiles = ctx.runfiles(transitive_files = files, collect_default = True)
+    runfiles = ctx.runfiles(
+        transitive_files = files,
+        collect_default = True,
+        root_symlinks = {"bin/runfiles.bash": ctx.file._runfiles_script},
+    )
     default_info = DefaultInfo(
         executable = main_executable,
         files = files,
@@ -59,6 +63,8 @@ def _sh_executable_impl(ctx):
 
     run_environment_info = RunEnvironmentInfo(
         environment = {
+            "RUNFILES_BIN": "../bin",
+        } | {
             key: ctx.expand_make_variables(
                 "env",
                 ctx.expand_location(value, ctx.attr.data, short_paths = True),
@@ -192,6 +198,10 @@ most build rules</a>.
             "env_inherit": attr.string_list(),
             "_windows_constraint": attr.label(
                 default = "@platforms//os:windows",
+            ),
+            "_runfiles_script": attr.label(
+                default = Label("//shell/runfiles:runfiles.bash"),
+                allow_single_file = True,
             ),
         } | extra_attrs,
         toolchains = [

--- a/shell/runfiles/BUILD
+++ b/shell/runfiles/BUILD
@@ -1,6 +1,11 @@
 load("//shell:sh_library.bzl", "sh_library")
 load("//shell/private:root_symlinks.bzl", "ROOT_SYMLINKS_SUPPORTED", "root_symlinks")
 
+exports_files(
+    srcs = ["runfiles.bash"],
+    visibility = ["//visibility:public"],
+)
+
 alias(
     name = "runfiles",
     actual = ":runfiles_impl" if ROOT_SYMLINKS_SUPPORTED else "@bazel_tools//tools/bash/runfiles",
@@ -11,6 +16,7 @@ sh_library(
     name = "runfiles_impl",
     data = [":runfiles_at_legacy_location"],
     tags = ["manual"],
+    deprecation = "Runfiles are now implicitly available when using sh_*() rules",
 )
 
 root_symlinks(

--- a/shell/runfiles/runfiles.bash
+++ b/shell/runfiles/runfiles.bash
@@ -58,7 +58,7 @@
 #       sh_binary(
 #           name = "my_binary",
 #           ...
-#           deps = ["@bazel_tools//tools/bash/runfiles"],
+#           deps = ["@rules_shell//shell/runfiles"],
 #       )
 #
 # 2.  Source the runfiles library.
@@ -67,18 +67,8 @@
 #     up the library's runtime location, thus we have a chicken-and-egg problem.
 #     Insert the following code snippet to the top of your main script:
 #
-#       # --- begin runfiles.bash initialization v3 ---
-#       # Copy-pasted from the Bazel Bash runfiles library v3.
-#       set -uo pipefail; set +e; f=bazel_tools/tools/bash/runfiles/runfiles.bash
-#       # shellcheck disable=SC1090
-#       source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
-#         source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
-#         source "$0.runfiles/$f" 2>/dev/null || \
-#         source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
-#         source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
-#         { echo>&2 "ERROR: cannot find $f"; exit 1; }; f=; set -e
-#       # --- end runfiles.bash initialization v3 ---
-#
+#       PATH=$PATH:$RUNFILES_BIN
+#       source runfiles.bash
 #
 # 3.  Use rlocation to look up runfile paths.
 #
@@ -90,7 +80,7 @@ if [[ ! -d "${RUNFILES_DIR:-/dev/null}" && ! -f "${RUNFILES_MANIFEST_FILE:-/dev/
     export RUNFILES_MANIFEST_FILE="$0.runfiles_manifest"
   elif [[ -f "$0.runfiles/MANIFEST" ]]; then
     export RUNFILES_MANIFEST_FILE="$0.runfiles/MANIFEST"
-  elif [[ -f "$0.runfiles/bazel_tools/tools/bash/runfiles/runfiles.bash" ]]; then
+  elif [[ -f "$0.runfiles/bin/runfiles.bash" ]]; then
     export RUNFILES_DIR="$0.runfiles"
   fi
 fi

--- a/tests/bcr/BUILD
+++ b/tests/bcr/BUILD
@@ -6,21 +6,16 @@ sh_library(
     name = "lib",
     srcs = ["lib.sh"],
     data = ["greeting.txt"],
-    deps = ["@rules_shell//shell/runfiles"],
 )
 
 sh_binary(
     name = "bin",
     srcs = ["bin.sh"],
-    deps = [
-        ":lib",
-        "@rules_shell//shell/runfiles",
-    ],
+    deps = [":lib"],
 )
 
 sh_test(
     name = "test",
     srcs = ["test.sh"],
     data = [":bin"],
-    deps = ["@rules_shell//shell/runfiles"],
 )

--- a/tests/bcr/bin.sh
+++ b/tests/bcr/bin.sh
@@ -13,17 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# --- begin runfiles.bash initialization v3 ---
-# Copy-pasted from the Bazel Bash runfiles library v3.
-set -uo pipefail; set +e; f=bazel_tools/tools/bash/runfiles/runfiles.bash
-# shellcheck disable=SC1090
-source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
-  source "$0.runfiles/$f" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
-  { echo>&2 "ERROR: cannot find $f"; exit 1; }; f=; set -e
-# --- end runfiles.bash initialization v3 ---
+set -euo pipefail
+PATH=$PATH:$RUNFILES_BIN
+source runfiles.bash
 
 source "$(rlocation "rules_shell_tests/lib.sh")"
 

--- a/tests/bcr/lib.sh
+++ b/tests/bcr/lib.sh
@@ -13,17 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# --- begin runfiles.bash initialization v3 ---
-# Copy-pasted from the Bazel Bash runfiles library v3.
-set -uo pipefail; set +e; f=bazel_tools/tools/bash/runfiles/runfiles.bash
-# shellcheck disable=SC1090
-source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
-  source "$0.runfiles/$f" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
-  { echo>&2 "ERROR: cannot find $f"; exit 1; }; f=; set -e
-# --- end runfiles.bash initialization v3 ---
+set -euo pipefail
 
 function get_greeting() {
     greeting_path=$(rlocation "rules_shell_tests/greeting.txt")

--- a/tests/bcr/test.sh
+++ b/tests/bcr/test.sh
@@ -13,17 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# --- begin runfiles.bash initialization v3 ---
-# Copy-pasted from the Bazel Bash runfiles library v3.
-set -uo pipefail; set +e; f=bazel_tools/tools/bash/runfiles/runfiles.bash
-# shellcheck disable=SC1090
-source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
-  source "$0.runfiles/$f" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
-  { echo>&2 "ERROR: cannot find $f"; exit 1; }; f=; set -e
-# --- end runfiles.bash initialization v3 ---
+set -euo pipefail
+PATH=$PATH:$RUNFILES_BIN
+source runfiles.bash
 
 bin_path="$(rlocation "rules_shell_tests/bin.sh")"
 if [[ ! -x "${bin_path}" ]]; then

--- a/tests/runfiles/runfiles_test.bash
+++ b/tests/runfiles/runfiles_test.bash
@@ -58,14 +58,14 @@ function find_runfiles_lib() {
       export RUNFILES_MANIFEST_FILE="$0.runfiles_manifest"
     elif [[ -f "$0.runfiles/MANIFEST" ]]; then
       export RUNFILES_MANIFEST_FILE="$0.runfiles/MANIFEST"
-    elif [[ -f "$0.runfiles/bazel_tools/tools/bash/runfiles/runfiles.bash" ]]; then
+    elif [[ -f "$0.runfiles/bin/runfiles.bash" ]]; then
       export RUNFILES_DIR="$0.runfiles"
     fi
   fi
-  if [[ -f "${RUNFILES_DIR:-/dev/null}/bazel_tools/tools/bash/runfiles/runfiles.bash" ]]; then
-    echo "${RUNFILES_DIR}/bazel_tools/tools/bash/runfiles/runfiles.bash"
+  if [[ -f "${RUNFILES_DIR:-/dev/null}/bin/runfiles.bash" ]]; then
+    echo "${RUNFILES_DIR}/bin/runfiles.bash"
   elif [[ -f "${RUNFILES_MANIFEST_FILE:-/dev/null}" ]]; then
-    grep -m1 "^bazel_tools/tools/bash/runfiles/runfiles.bash " \
+    grep -m1 "^bin/runfiles.bash " \
         "$RUNFILES_MANIFEST_FILE" | cut -d ' ' -f 2-
   else
     echo >&2 "ERROR: cannot find //shell/runfiles:runfiles.bash"


### PR DESCRIPTION
This significantly simplifies the snippet which needs to be copied into every main script.