### PR TITLE
Configure coverage helpers for test exec group

### DIFF
--- a/shell/private/sh_test.bzl
+++ b/shell/private/sh_test.bzl
@@ -24,14 +24,14 @@ sh_test = make_sh_executable_rule(
     fragments = ["coverage"],
     extra_attrs = {
         "_lcov_merger": attr.label(
-            cfg = "exec",
+            cfg = config.exec(exec_group = "test"),
             default = configuration_field(fragment = "coverage", name = "output_generator"),
             executable = True,
         ),
         # Add the script as an attribute in order for sh_test to output code coverage results for
         # code covered by CC binaries invocations.
         "_collect_cc_coverage": attr.label(
-            cfg = "exec",
+            cfg = config.exec(exec_group = "test"),
             default = "@bazel_tools//tools/test:collect_cc_coverage",
             executable = True,
         ),


### PR DESCRIPTION
They are run on the test action's execution platform, which is resolved for the `test` exec group, not the default one.