### PR TITLE
Update runfiles library label in setup instructions

### DIFF
--- a/shell/runfiles/runfiles.bash
+++ b/shell/runfiles/runfiles.bash
@@ -58,7 +58,7 @@
 #       sh_binary(
 #           name = "my_binary",
 #           ...
-#           deps = ["@bazel_tools//tools/bash/runfiles"],
+#           deps = ["@rules_shell//shell/runfiles"],
 #       )
 #
 # 2.  Source the runfiles library.


### PR DESCRIPTION
This still pointed to `bazel_tools`, which works for now but should be dropped eventually.