### PR TITLE
fix: do not allow GREP_XXX env vars from breaking `rlocation`

### DIFF
--- a/shell/runfiles/runfiles.bash
+++ b/shell/runfiles/runfiles.bash
@@ -115,9 +115,7 @@ esac
 function __runfiles_maybe_grep() {
   # The GREP_XXX variables influence how grep behaves. Specifically, they can
   # affect the output from the grep command.
-  unset GREP_COLOR
-  unset GREP_OPTIONS
-  grep $_RLOCATION_GREP_CASE_INSENSITIVE_ARGS "$@" || test $? = 1;
+  GREP_COLOR="" GREP_OPTIONS="" grep $_RLOCATION_GREP_CASE_INSENSITIVE_ARGS "$@" || test $? = 1;
 }
 export -f __runfiles_maybe_grep
 

--- a/shell/runfiles/runfiles.bash
+++ b/shell/runfiles/runfiles.bash
@@ -96,18 +96,18 @@ if [[ ! -d "${RUNFILES_DIR:-/dev/null}" && ! -f "${RUNFILES_MANIFEST_FILE:-/dev/
 fi
 
 case "$(uname -s | tr '[:upper:]' '[:lower:]')" in
-  msys* | mingw* | cygwin*)
-    # matches an absolute Windows path
-    export _RLOCATION_ISABS_PATTERN="^[a-zA-Z]:[/\\]"
-    # Windows paths are case insensitive and Bazel and MSYS2 capitalize differently, so we can't
-    # assume that all paths are in the same native case.
-    export _RLOCATION_GREP_CASE_INSENSITIVE_ARGS=-i
-    ;;
-  *)
-    # matches an absolute Unix path
-    export _RLOCATION_ISABS_PATTERN="^/[^/].*"
-    export _RLOCATION_GREP_CASE_INSENSITIVE_ARGS=
-    ;;
+msys*|mingw*|cygwin*)
+  # matches an absolute Windows path
+  export _RLOCATION_ISABS_PATTERN="^[a-zA-Z]:[/\\]"
+  # Windows paths are case insensitive and Bazel and MSYS2 capitalize differently, so we can't
+  # assume that all paths are in the same native case.
+  export _RLOCATION_GREP_CASE_INSENSITIVE_ARGS=-i
+  ;;
+*)
+  # matches an absolute Unix path
+  export _RLOCATION_ISABS_PATTERN="^/[^/].*"
+  export _RLOCATION_GREP_CASE_INSENSITIVE_ARGS=
+  ;;
 esac
 
 # Does not exit with a non-zero exit code if no match is found and performs a case-insensitive
@@ -117,7 +117,7 @@ function __runfiles_maybe_grep() {
   # affect the output from the grep command.
   unset GREP_COLOR
   unset GREP_OPTIONS
-  grep $_RLOCATION_GREP_CASE_INSENSITIVE_ARGS "$@" || test $? = 1
+  grep $_RLOCATION_GREP_CASE_INSENSITIVE_ARGS "$@" || test $? = 1;
 }
 export -f __runfiles_maybe_grep
 
@@ -152,7 +152,7 @@ function rlocation() {
   elif [[ "$1" == \\* ]]; then
     if [[ "${RUNFILES_LIB_DEBUG:-}" == 1 ]]; then
       echo >&2 "ERROR[runfiles.bash]: rlocation($1): absolute path without" \
-        "drive name"
+               "drive name"
     fi
     return 1
   fi
@@ -215,8 +215,8 @@ export -f rlocation
 # libraries under @bazel_tools//tools/<lang>/runfiles, then that binary needs
 # these envvars in order to initialize its own runfiles library.
 function runfiles_export_envvars() {
-  if [[ ! -f "${RUNFILES_MANIFEST_FILE:-/dev/null}" &&
-    ! -d "${RUNFILES_DIR:-/dev/null}" ]]; then
+  if [[ ! -f "${RUNFILES_MANIFEST_FILE:-/dev/null}" \
+        && ! -d "${RUNFILES_DIR:-/dev/null}" ]]; then
     return 1
   fi
 
@@ -229,12 +229,12 @@ function runfiles_export_envvars() {
       export RUNFILES_MANIFEST_FILE=
     fi
   elif [[ ! -d "${RUNFILES_DIR:-/dev/null}" ]]; then
-    if [[ "$RUNFILES_MANIFEST_FILE" == */MANIFEST &&
-      -d "${RUNFILES_MANIFEST_FILE%/MANIFEST}" ]]; then
+    if [[ "$RUNFILES_MANIFEST_FILE" == */MANIFEST \
+          && -d "${RUNFILES_MANIFEST_FILE%/MANIFEST}" ]]; then
       export RUNFILES_DIR="${RUNFILES_MANIFEST_FILE%/MANIFEST}"
       export JAVA_RUNFILES="$RUNFILES_DIR"
-    elif [[ "$RUNFILES_MANIFEST_FILE" == *_manifest &&
-      -d "${RUNFILES_MANIFEST_FILE%_manifest}" ]]; then
+    elif [[ "$RUNFILES_MANIFEST_FILE" == *_manifest \
+          && -d "${RUNFILES_MANIFEST_FILE%_manifest}" ]]; then
       export RUNFILES_DIR="${RUNFILES_MANIFEST_FILE%_manifest}"
       export JAVA_RUNFILES="$RUNFILES_DIR"
     else
@@ -260,10 +260,7 @@ function runfiles_current_repository() {
   if [[ "$raw_caller_path" =~ $_RLOCATION_ISABS_PATTERN ]]; then
     local -r caller_path="$raw_caller_path"
   else
-    local -r caller_path="$(
-      cd "$(dirname "$raw_caller_path")" || return 1
-      pwd
-    )/$(basename "$raw_caller_path")"
+    local -r caller_path="$(cd "$(dirname "$raw_caller_path")" || return 1; pwd)/$(basename "$raw_caller_path")"
   fi
   if [[ "${RUNFILES_LIB_DEBUG:-}" == 1 ]]; then
     echo >&2 "INFO[runfiles.bash]: runfiles_current_repository($idx): caller's path is ($caller_path)"
@@ -489,8 +486,8 @@ function runfiles_rlocation_checked() {
   else
     if [[ "${RUNFILES_LIB_DEBUG:-}" == 1 ]]; then
       echo >&2 "ERROR[runfiles.bash]: cannot look up runfile \"$1\" " \
-        "(RUNFILES_DIR=\"${RUNFILES_DIR:-}\"," \
-        "RUNFILES_MANIFEST_FILE=\"${RUNFILES_MANIFEST_FILE:-}\")"
+               "(RUNFILES_DIR=\"${RUNFILES_DIR:-}\"," \
+               "RUNFILES_MANIFEST_FILE=\"${RUNFILES_MANIFEST_FILE:-}\")"
     fi
     return 1
   fi

--- a/tests/runfiles/runfiles_test.bash
+++ b/tests/runfiles/runfiles_test.bash
@@ -38,12 +38,12 @@ function log_info() {
 which uname >&/dev/null || fail "cannot locate GNU coreutils"
 
 case "$(uname -s | tr [:upper:] [:lower:])" in
-  msys* | mingw* | cygwin*)
-    function is_windows() { true; }
-    ;;
-  *)
-    function is_windows() { false; }
-    ;;
+msys*|mingw*|cygwin*)
+  function is_windows() { true; }
+  ;;
+*)
+  function is_windows() { false; }
+  ;;
 esac
 
 function find_runfiles_lib() {
@@ -66,7 +66,7 @@ function find_runfiles_lib() {
     echo "${RUNFILES_DIR}/bazel_tools/tools/bash/runfiles/runfiles.bash"
   elif [[ -f "${RUNFILES_MANIFEST_FILE:-/dev/null}" ]]; then
     grep -m1 "^bazel_tools/tools/bash/runfiles/runfiles.bash " \
-      "$RUNFILES_MANIFEST_FILE" | cut -d ' ' -f 2-
+        "$RUNFILES_MANIFEST_FILE" | cut -d ' ' -f 2-
   else
     echo >&2 "ERROR: cannot find //shell/runfiles:runfiles.bash"
     exit 1
@@ -135,7 +135,7 @@ function test_rlocation_abs_path() {
 
 function test_init_manifest_based_runfiles() {
   local tmpdir="$(mktemp -d $TEST_TMPDIR/tmp.XXXXXXXX)"
-  cat >$tmpdir/foo.runfiles_manifest <<EOF
+  cat > $tmpdir/foo.runfiles_manifest << EOF
 a/b $tmpdir/c/d
 e/f $tmpdir/g h
 y $tmpdir/y
@@ -211,7 +211,7 @@ EOF
 
 function test_manifest_based_envvars() {
   local tmpdir="$(mktemp -d $TEST_TMPDIR/tmp.XXXXXXXX)"
-  echo "a b" >$tmpdir/foo.runfiles_manifest
+  echo "a b" > $tmpdir/foo.runfiles_manifest
 
   export RUNFILES_DIR=
   export RUNFILES_MANIFEST_FILE=$tmpdir/foo.runfiles_manifest
@@ -248,7 +248,7 @@ function test_directory_based_runfiles_with_repo_mapping_from_main() {
 
   export RUNFILES_DIR=${tmpdir}/mock/runfiles
   mkdir -p "$RUNFILES_DIR"
-  cat >"$RUNFILES_DIR/_repo_mapping" <<EOF
+  cat > "$RUNFILES_DIR/_repo_mapping" <<EOF
 ,config.json,config.json+1.2.3
 ,my_module,_main
 ,my_protobuf,protobuf+3.19.2
@@ -292,7 +292,7 @@ function test_directory_based_runfiles_with_repo_mapping_from_other_repo() {
 
   export RUNFILES_DIR=${tmpdir}/mock/runfiles
   mkdir -p "$RUNFILES_DIR"
-  cat >"$RUNFILES_DIR/_repo_mapping" <<EOF
+  cat > "$RUNFILES_DIR/_repo_mapping" <<EOF
 ,config.json,config.json+1.2.3
 ,my_module,_main
 ,my_protobuf,protobuf+3.19.2
@@ -334,7 +334,7 @@ function test_directory_based_runfiles_with_repo_mapping_from_extension_repo() {
 
   export RUNFILES_DIR=${tmpdir}/mock/runfiles
   mkdir -p "$RUNFILES_DIR"
-  cat >"$RUNFILES_DIR/_repo_mapping" <<EOF
+  cat > "$RUNFILES_DIR/_repo_mapping" <<EOF
 ,config.json,config.json+1.2.3
 ,my_module,_main
 ,my_protobuf,protobuf+3.19.2
@@ -370,7 +370,7 @@ EOF
 function test_manifest_based_runfiles_with_repo_mapping_from_main() {
   local tmpdir="$(mktemp -d $TEST_TMPDIR/tmp.XXXXXXXX)"
 
-  cat >"$tmpdir/foo.repo_mapping" <<EOF
+  cat > "$tmpdir/foo.repo_mapping" <<EOF
 ,config.json,config.json+1.2.3
 ,my_module,_main
 ,my_protobuf,protobuf+3.19.2
@@ -380,7 +380,7 @@ protobuf+3.19.2,config.json,config.json+1.2.3
 EOF
   export RUNFILES_DIR=
   export RUNFILES_MANIFEST_FILE="$tmpdir/foo.runfiles_manifest"
-  cat >"$RUNFILES_MANIFEST_FILE" <<EOF
+  cat > "$RUNFILES_MANIFEST_FILE" << EOF
 _repo_mapping $tmpdir/foo.repo_mapping
 config.json $tmpdir/config.json
 protobuf+3.19.2/foo/runfile $tmpdir/protobuf+3.19.2/foo/runfile
@@ -420,7 +420,7 @@ EOF
 function test_manifest_based_runfiles_with_repo_mapping_from_other_repo() {
   local tmpdir="$(mktemp -d $TEST_TMPDIR/tmp.XXXXXXXX)"
 
-  cat >"$tmpdir/foo.repo_mapping" <<EOF
+  cat > "$tmpdir/foo.repo_mapping" <<EOF
 ,config.json,config.json+1.2.3
 ,my_module,_main
 ,my_protobuf,protobuf+3.19.2
@@ -430,7 +430,7 @@ protobuf+3.19.2,config.json,config.json+1.2.3
 EOF
   export RUNFILES_DIR=
   export RUNFILES_MANIFEST_FILE="$tmpdir/foo.runfiles_manifest"
-  cat >"$RUNFILES_MANIFEST_FILE" <<EOF
+  cat > "$RUNFILES_MANIFEST_FILE" << EOF
 _repo_mapping $tmpdir/foo.repo_mapping
 config.json $tmpdir/config.json
 protobuf+3.19.2/foo/runfile $tmpdir/protobuf+3.19.2/foo/runfile
@@ -468,7 +468,7 @@ EOF
 function test_manifest_based_runfiles_with_repo_mapping_from_extension_repo() {
   local tmpdir="$(mktemp -d $TEST_TMPDIR/tmp.XXXXXXXX)"
 
-  cat >"$tmpdir/foo.repo_mapping" <<EOF
+  cat > "$tmpdir/foo.repo_mapping" <<EOF
 ,config.json,config.json+1.2.3
 ,my_module,_main
 ,my_protobuf,protobuf+3.19.2
@@ -480,7 +480,7 @@ my_module++ext1+*,my_module,my_module+
 EOF
   export RUNFILES_DIR=
   export RUNFILES_MANIFEST_FILE="$tmpdir/foo.runfiles_manifest"
-  cat >"$RUNFILES_MANIFEST_FILE" <<EOF
+  cat > "$RUNFILES_MANIFEST_FILE" << EOF
 _repo_mapping $tmpdir/foo.repo_mapping
 config.json $tmpdir/config.json
 protobuf+3.19.2/foo/runfile $tmpdir/protobuf+3.19.2/foo/runfile

--- a/tests/runfiles/runfiles_test.bash
+++ b/tests/runfiles/runfiles_test.bash
@@ -38,12 +38,12 @@ function log_info() {
 which uname >&/dev/null || fail "cannot locate GNU coreutils"
 
 case "$(uname -s | tr [:upper:] [:lower:])" in
-msys*|mingw*|cygwin*)
-  function is_windows() { true; }
-  ;;
-*)
-  function is_windows() { false; }
-  ;;
+  msys* | mingw* | cygwin*)
+    function is_windows() { true; }
+    ;;
+  *)
+    function is_windows() { false; }
+    ;;
 esac
 
 function find_runfiles_lib() {
@@ -66,7 +66,7 @@ function find_runfiles_lib() {
     echo "${RUNFILES_DIR}/bazel_tools/tools/bash/runfiles/runfiles.bash"
   elif [[ -f "${RUNFILES_MANIFEST_FILE:-/dev/null}" ]]; then
     grep -m1 "^bazel_tools/tools/bash/runfiles/runfiles.bash " \
-        "$RUNFILES_MANIFEST_FILE" | cut -d ' ' -f 2-
+      "$RUNFILES_MANIFEST_FILE" | cut -d ' ' -f 2-
   else
     echo >&2 "ERROR: cannot find //shell/runfiles:runfiles.bash"
     exit 1
@@ -135,7 +135,7 @@ function test_rlocation_abs_path() {
 
 function test_init_manifest_based_runfiles() {
   local tmpdir="$(mktemp -d $TEST_TMPDIR/tmp.XXXXXXXX)"
-  cat > $tmpdir/foo.runfiles_manifest << EOF
+  cat >$tmpdir/foo.runfiles_manifest <<EOF
 a/b $tmpdir/c/d
 e/f $tmpdir/g h
 y $tmpdir/y
@@ -211,7 +211,7 @@ EOF
 
 function test_manifest_based_envvars() {
   local tmpdir="$(mktemp -d $TEST_TMPDIR/tmp.XXXXXXXX)"
-  echo "a b" > $tmpdir/foo.runfiles_manifest
+  echo "a b" >$tmpdir/foo.runfiles_manifest
 
   export RUNFILES_DIR=
   export RUNFILES_MANIFEST_FILE=$tmpdir/foo.runfiles_manifest
@@ -248,7 +248,7 @@ function test_directory_based_runfiles_with_repo_mapping_from_main() {
 
   export RUNFILES_DIR=${tmpdir}/mock/runfiles
   mkdir -p "$RUNFILES_DIR"
-  cat > "$RUNFILES_DIR/_repo_mapping" <<EOF
+  cat >"$RUNFILES_DIR/_repo_mapping" <<EOF
 ,config.json,config.json+1.2.3
 ,my_module,_main
 ,my_protobuf,protobuf+3.19.2
@@ -292,7 +292,7 @@ function test_directory_based_runfiles_with_repo_mapping_from_other_repo() {
 
   export RUNFILES_DIR=${tmpdir}/mock/runfiles
   mkdir -p "$RUNFILES_DIR"
-  cat > "$RUNFILES_DIR/_repo_mapping" <<EOF
+  cat >"$RUNFILES_DIR/_repo_mapping" <<EOF
 ,config.json,config.json+1.2.3
 ,my_module,_main
 ,my_protobuf,protobuf+3.19.2
@@ -334,7 +334,7 @@ function test_directory_based_runfiles_with_repo_mapping_from_extension_repo() {
 
   export RUNFILES_DIR=${tmpdir}/mock/runfiles
   mkdir -p "$RUNFILES_DIR"
-  cat > "$RUNFILES_DIR/_repo_mapping" <<EOF
+  cat >"$RUNFILES_DIR/_repo_mapping" <<EOF
 ,config.json,config.json+1.2.3
 ,my_module,_main
 ,my_protobuf,protobuf+3.19.2
@@ -370,7 +370,7 @@ EOF
 function test_manifest_based_runfiles_with_repo_mapping_from_main() {
   local tmpdir="$(mktemp -d $TEST_TMPDIR/tmp.XXXXXXXX)"
 
-  cat > "$tmpdir/foo.repo_mapping" <<EOF
+  cat >"$tmpdir/foo.repo_mapping" <<EOF
 ,config.json,config.json+1.2.3
 ,my_module,_main
 ,my_protobuf,protobuf+3.19.2
@@ -380,7 +380,7 @@ protobuf+3.19.2,config.json,config.json+1.2.3
 EOF
   export RUNFILES_DIR=
   export RUNFILES_MANIFEST_FILE="$tmpdir/foo.runfiles_manifest"
-  cat > "$RUNFILES_MANIFEST_FILE" << EOF
+  cat >"$RUNFILES_MANIFEST_FILE" <<EOF
 _repo_mapping $tmpdir/foo.repo_mapping
 config.json $tmpdir/config.json
 protobuf+3.19.2/foo/runfile $tmpdir/protobuf+3.19.2/foo/runfile
@@ -420,7 +420,7 @@ EOF
 function test_manifest_based_runfiles_with_repo_mapping_from_other_repo() {
   local tmpdir="$(mktemp -d $TEST_TMPDIR/tmp.XXXXXXXX)"
 
-  cat > "$tmpdir/foo.repo_mapping" <<EOF
+  cat >"$tmpdir/foo.repo_mapping" <<EOF
 ,config.json,config.json+1.2.3
 ,my_module,_main
 ,my_protobuf,protobuf+3.19.2
@@ -430,7 +430,7 @@ protobuf+3.19.2,config.json,config.json+1.2.3
 EOF
   export RUNFILES_DIR=
   export RUNFILES_MANIFEST_FILE="$tmpdir/foo.runfiles_manifest"
-  cat > "$RUNFILES_MANIFEST_FILE" << EOF
+  cat >"$RUNFILES_MANIFEST_FILE" <<EOF
 _repo_mapping $tmpdir/foo.repo_mapping
 config.json $tmpdir/config.json
 protobuf+3.19.2/foo/runfile $tmpdir/protobuf+3.19.2/foo/runfile
@@ -468,7 +468,7 @@ EOF
 function test_manifest_based_runfiles_with_repo_mapping_from_extension_repo() {
   local tmpdir="$(mktemp -d $TEST_TMPDIR/tmp.XXXXXXXX)"
 
-  cat > "$tmpdir/foo.repo_mapping" <<EOF
+  cat >"$tmpdir/foo.repo_mapping" <<EOF
 ,config.json,config.json+1.2.3
 ,my_module,_main
 ,my_protobuf,protobuf+3.19.2
@@ -480,7 +480,7 @@ my_module++ext1+*,my_module,my_module+
 EOF
   export RUNFILES_DIR=
   export RUNFILES_MANIFEST_FILE="$tmpdir/foo.runfiles_manifest"
-  cat > "$RUNFILES_MANIFEST_FILE" << EOF
+  cat >"$RUNFILES_MANIFEST_FILE" <<EOF
 _repo_mapping $tmpdir/foo.repo_mapping
 config.json $tmpdir/config.json
 protobuf+3.19.2/foo/runfile $tmpdir/protobuf+3.19.2/foo/runfile
@@ -520,6 +520,13 @@ function test_directory_based_envvars() {
   runfiles_export_envvars
   [[ "${RUNFILES_DIR:-}" == "mock/runfiles" ]] || fail
   [[ -z "${RUNFILES_MANIFEST_FILE:-}" ]] || fail
+}
+
+function test_with_grep_env_vars_set() {
+  # These influence how grep behaves.
+  export GREP_COLOR='1;35;40'
+  export GREP_OPTIONS='--color=always'
+  test_init_manifest_based_runfiles
 }
 
 function main() {


### PR DESCRIPTION
The grep command can be influenced by `GREP_XXX` environment variables. If set, they can affect the behavior/output of the command, causing `rlocation` to fail.
