### PR TITLE
Add a 'tools' attribute to the rules, similar to genrule

### DIFF
--- a/shell/private/sh_library.bzl
+++ b/shell/private/sh_library.bzl
@@ -25,6 +25,8 @@ def _sh_library_impl(ctx):
         transitive_files.append(target[DefaultInfo].files)
     for target in ctx.attr.data:
         transitive_files.append(target[DefaultInfo].files)
+    for target in ctx.attr.tools:
+        transitive_files.append(target[DefaultInfo].files)
     files = depset(transitive = transitive_files)
 
     runfiles = ctx.runfiles(transitive_files = files, collect_default = True)
@@ -32,7 +34,7 @@ def _sh_library_impl(ctx):
     instrumented_files_info = coverage_common.instrumented_files_info(
         ctx,
         source_attributes = ["srcs"],
-        dependency_attributes = ["deps", "data"],
+        dependency_attributes = ["deps", "data", "tools"],
     )
 
     return [
@@ -112,6 +114,15 @@ most build rules</a>.
   interpreted program source code depended on by the code in <code>srcs</code>. The files
   provided by these rules will be present among the <code>runfiles</code> of this target.
 </p>
+""",
+        ),
+        "tools": attr.label_list(
+            cfg = config.exec(),
+            allow_files = True,
+            doc = """
+The list of tool dependencies, similar to genrule's equivalent. You can use
+this to ensure that any helper binaries your scripts need are built in the exec
+configuration.
 """,
         ),
     },

--- a/tests/bcr/BUILD
+++ b/tests/bcr/BUILD
@@ -1,11 +1,32 @@
 load("@rules_shell//shell:sh_binary.bzl", "sh_binary")
 load("@rules_shell//shell:sh_library.bzl", "sh_library")
 load("@rules_shell//shell:sh_test.bzl", "sh_test")
+load(":is_exec_configuration.bzl", "is_exec_configuration")
+
+is_exec_configuration(
+    name = "_is_exec_configuration",
+    visibility = ["//visibility:private"],
+)
+
+config_setting(
+    name = "config_exec",
+    flag_values = {":_is_exec_configuration": "yes"},
+    visibility = ["//visibility:private"],
+)
+
+alias(
+    name = "greetings",
+    actual = select({
+        ":config_exec": "greeting_tool.txt",
+        "//conditions:default": "greeting.txt",
+    }),
+)
 
 sh_library(
     name = "lib",
     srcs = ["lib.sh"],
     data = ["greeting.txt"],
+    tools = ["greetings"],
     deps = ["@rules_shell//shell/runfiles"],
 )
 

--- a/tests/bcr/bin.sh
+++ b/tests/bcr/bin.sh
@@ -28,3 +28,5 @@ source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
 source "$(rlocation "rules_shell_tests/lib.sh")"
 
 get_greeting
+
+get_tool_greeting

--- a/tests/bcr/greeting_tool.txt
+++ b/tests/bcr/greeting_tool.txt
@@ -1,0 +1,1 @@
+and the tools

--- a/tests/bcr/is_exec_configuration.bzl
+++ b/tests/bcr/is_exec_configuration.bzl
@@ -1,0 +1,12 @@
+def _is_exec_configuration(ctx):
+    # https://github.com/bazelbuild/bazel/issues/14444
+    return config_common.FeatureFlagInfo(
+        # feature flags must be strings, so we're avoiding True and False in
+        # favor of "yes" and "no" to avoid confusion between "True" and True
+        value = "yes" if "-exec" in ctx.bin_dir.path else "no",
+    )
+
+is_exec_configuration = rule(
+    doc = "identify if the current target is in exec configuration",
+    implementation = _is_exec_configuration,
+)

--- a/tests/bcr/lib.sh
+++ b/tests/bcr/lib.sh
@@ -29,3 +29,8 @@ function get_greeting() {
     greeting_path=$(rlocation "rules_shell_tests/greeting.txt")
     cat "${greeting_path}"
 }
+
+function get_tool_greeting() {
+    greeting_path=$(rlocation "rules_shell_tests/greeting_tool.txt")
+    cat "${greeting_path}"
+}

--- a/tests/bcr/test.sh
+++ b/tests/bcr/test.sh
@@ -33,8 +33,13 @@ fi
 
 runfiles_export_envvars
 
+read -r -d '' expected <<EOF || true
+hello from rules_shell
+and the tools
+EOF
+
 greeting=$("${bin_path}")
-if [[ "${greeting}" != "hello from rules_shell" ]]; then
-  echo "Expected 'hello from rules_shell', got '${greeting}'"
+if [[ "${greeting}" != "${expected}" ]]; then
+  printf "Expected '%s', got '%s'\n" "${expected}" "${greeting}"
   exit 1
 fi


### PR DESCRIPTION
It's common for shell scripts to use external binaries (things from coreutils being a common example). This provides a way to declare those dependencies explicitly, and ensure they are in the correct configuration to be run as part of the script.