### PR TITLE
Add providers.bzl to `shell/private:private_bzl`

### DIFF
--- a/shell/private/BUILD
+++ b/shell/private/BUILD
@@ -3,6 +3,7 @@ load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 bzl_library(
     name = "private_bzl",
     srcs = [
+        "providers.bzl",
         "sh_binary.bzl",
         "sh_executable.bzl",
         "sh_library.bzl",


### PR DESCRIPTION
This file is missing in the bzl_library target which makes starlark generation fail for example:

```
Stardoc documentation generation failed: File /home/runner/.cache/bazel/_bazel_runner/c91220d87f26118b19246641d5266d21/sandbox/processwrapper-sandbox/251/execroot/rules_haskell/bazel-out/k8-opt-exec-2B5CBBC6/bin/docs/defs_metadata_stardoc.runfiles/rules_shell/shell/private/sh_executable.bzl imported ':providers.bzl', yet /home/runner/.cache/bazel/_bazel_runner/c91220d87f26118b19246641d5266d21/sandbox/processwrapper-sandbox/251/execroot/rules_haskell/bazel-out/k8-opt-exec-2B5CBBC6/bin/docs/defs_metadata_stardoc.runfiles/rules_shell/shell/private/providers.bzl was not found.
```
