### PR TITLE
Return repo_metadata from repository_rule

### DIFF
--- a/shell/private/repositories/sh_config.bzl
+++ b/shell/private/repositories/sh_config.bzl
@@ -85,6 +85,10 @@ def _sh_config_impl(repository_ctx):
 load("@rules_shell//shell/toolchains:sh_toolchain.bzl", "sh_toolchain")
 """ + "\n".join(toolchains))
 
+    if hasattr(repository_ctx, "repo_metadata"):
+        return repository_ctx.repo_metadata(reproducible = False)
+    return None
+
 sh_config = repository_rule(
     environ = [
         "BAZEL_SH",


### PR DESCRIPTION
This is just being explicit about its non-reproducibility to satisfy https://github.com/bazelbuild/bazel/pull/30202
